### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Demo：http://itlwei.github.io/chess/
 
 中国象棋 - in html5是一款使用html5 canvas开发的开源小游戏，不依赖任何类库，不依赖任何后台程序，全部原生Javascript进行AI计算，欢迎广大业内同行多多交流指正，共同完善。
 
-##特点
+## 特点
 
 * 全部使用Javascript完成AI人工智能计算，不依赖任何后台程序
 * 不依赖任何类库，全部原生Javascript，使用html5 canvas.
 * 实现中不涉及任何浏览器特性，所以不存在浏览器兼容性问题.
 * 代码结构极其简洁明了，你可以轻易的阅读，修改成自己版本.
 
-##Change Log
+## Change Log
 ### v1.0.3
 * 增加历史表，提高AI计算效率
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
